### PR TITLE
Migrated some tests to []stack structure

### DIFF
--- a/netpol/pkg/utils/networkpolicyspecbuilder.go
+++ b/netpol/pkg/utils/networkpolicyspecbuilder.go
@@ -38,6 +38,7 @@ func (n *NetworkPolicySpecBuilder) SetName(namespace string, name string) *Netwo
 	return n
 }
 
+// TODO: Sedef: Test match expressions
 func (n *NetworkPolicySpecBuilder) AddIngress(protoc *v1.Protocol, port *int, portName *string, cidr *string, podSelector map[string]string, nsSelector map[string]string, podSelectorMatchExp *[]metav1.LabelSelectorRequirement, nsSelectorMatchExp *[]metav1.LabelSelectorRequirement) *NetworkPolicySpecBuilder {
 
 	var ps *metav1.LabelSelector
@@ -50,10 +51,29 @@ func (n *NetworkPolicySpecBuilder) AddIngress(protoc *v1.Protocol, port *int, po
 		ps = &metav1.LabelSelector{
 			MatchLabels: podSelector,
 		}
+		if podSelectorMatchExp != nil{
+			ps.MatchExpressions = *podSelectorMatchExp
+		}
 	}
+
+	if podSelectorMatchExp != nil {
+		ps = &metav1.LabelSelector{
+			MatchExpressions: *podSelectorMatchExp,
+		}
+	}
+
 	if nsSelector != nil {
 		ns = &metav1.LabelSelector{
 			MatchLabels: nsSelector,
+		}
+		if nsSelectorMatchExp != nil {
+			ns.MatchExpressions = *nsSelectorMatchExp
+		}
+	}
+
+	if nsSelectorMatchExp != nil {
+		ns = &metav1.LabelSelector{
+			MatchExpressions: *nsSelectorMatchExp,
 		}
 	}
 


### PR DESCRIPTION

1) Changed some tests' return type to []stack and did some cleanup
2) Incorporated podSelectorMatchExp and nsSelectorMatchExp to AddIngress()
3) To test ports 80 and 81 without doing stacked nw policies, sending same network policy with different reachability matrices and ports work. Did this for a couple of TODOs.

Also, you can see the tests ported in this excel:
https://docs.google.com/spreadsheets/d/12FqP7VIuJnpXdkXw2v8ry-9rV4mF_nSm8iCowGADXr8/edit?usp=sharing

cc @jayunit100 @mattfenwick 